### PR TITLE
Various Fixes

### DIFF
--- a/Imperium/Imperium.csproj
+++ b/Imperium/Imperium.csproj
@@ -32,9 +32,9 @@
         <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" ExcludeAssets="runtime" />
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.21" IncludeAssets="compile" />
 
-        <PackageReference Include="Rune580.Mods.Repo.RepoSteamNetworking" Version="0.1.0" />
+        <PackageReference Include="Rune580.Mods.Repo.RepoSteamNetworking" Version="0.1.2-dev.1" />
         <PackageReference Include="Zehs.REPOLib" Version="2.1.0" />
-        <PackageReference Include="rainbowblood.UniverseLib.Mono" Version="2.*" Publicize="true" />
+        <PackageReference Include="rainbowblood.UniverseLib.Mono" Version="2.*" />
         <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="*-*" PrivateAssets="all" Publicize="true" />
 
         <PackageReference Include="MinVer" Version="4.3.0">
@@ -44,7 +44,7 @@
 
         <ProjectReference Include="..\librarium\Librarium\Librarium.csproj" />
 
-        <Reference Include="UnityExplorer.BIE5.Mono" HintPath="..\deps\UnityExplorer.BIE5.Mono.dll" Publicize="true" />
+        <Reference Include="UnityExplorer.BIE5.Mono" HintPath="..\deps\UnityExplorer.BIE5.Mono.dll" />
     </ItemGroup>
 
     <!-- Enable debug symbols. This will show source code line numbers in stack traces. -->

--- a/Imperium/src/Core/ImpConstants.cs
+++ b/Imperium/src/Core/ImpConstants.cs
@@ -98,7 +98,7 @@ public struct ImpConstants
     [
         "Lobby Menu",
         "Main Menu",
-        "Recording",
+        "Splash Screen",
         "Tutorial"
     ];
 

--- a/Imperium/src/Core/Lifecycle/GameManager.cs
+++ b/Imperium/src/Core/Lifecycle/GameManager.cs
@@ -68,10 +68,7 @@ internal class GameManager : ImpLifecycleObject
 
     internal static bool IsGameLevel()
     {
-        return RunManager.instance.levelCurrent != RunManager.instance.levelLobbyMenu &&
-               RunManager.instance.levelCurrent != RunManager.instance.levelMainMenu &&
-               RunManager.instance.levelCurrent != RunManager.instance.levelLobby &&
-               RunManager.instance.levelCurrent != RunManager.instance.levelTutorial;
+        return SemiFunc.RunIsArena() || SemiFunc.RunIsLevel() || SemiFunc.RunIsShop() || SemiFunc.RunIsRecording();
     }
 
     internal static string GetEnemyState(EnemyParent enemyParent)

--- a/Imperium/src/Networking/ImpNetworking.cs
+++ b/Imperium/src/Networking/ImpNetworking.cs
@@ -204,7 +204,7 @@ public class ImpNetworking
     }
 
     [ImpAttributes.LocalMethod]
-    private void OnAuthenticateResponse()
+    internal void OnAuthenticateResponse()
     {
         ImperiumAccessGranted = true;
 

--- a/Imperium/src/Patches/PreInitPatches.cs
+++ b/Imperium/src/Patches/PreInitPatches.cs
@@ -46,7 +46,8 @@ internal static class PreInitPatches
             }
             else
             {
-                // Fixes imperium being disabled when using a mod that enables the lobby menu in singleplayer
+                // Fixes imperium being disabled when using a mod that can enable the lobby menu in singleplayer
+                // Example: https://thunderstore.io/c/repo/p/Dev1A3/LobbyImprovements_REPO/
                 Imperium.Networking.OnAuthenticateResponse();
             }
         }

--- a/Imperium/src/Patches/PreInitPatches.cs
+++ b/Imperium/src/Patches/PreInitPatches.cs
@@ -40,7 +40,14 @@ internal static class PreInitPatches
         }
         else if (RunManager.instance.levelCurrent == RunManager.instance.levelLobbyMenu)
         {
-            Imperium.Networking.RequestImperiumAccess();
+            if (SemiFunc.IsMultiplayer())
+            {
+                Imperium.Networking.RequestImperiumAccess();
+            }
+            else
+            {
+                Imperium.Networking.OnAuthenticateResponse();
+            }
         }
     }
 

--- a/Imperium/src/Patches/PreInitPatches.cs
+++ b/Imperium/src/Patches/PreInitPatches.cs
@@ -46,7 +46,7 @@ internal static class PreInitPatches
             }
             else
             {
-                // Fixes imperium not working when using a mod that enables the lobby menu in singleplayer
+                // Fixes imperium being disabled when using a mod that enables the lobby menu in singleplayer
                 Imperium.Networking.OnAuthenticateResponse();
             }
         }

--- a/Imperium/src/Patches/PreInitPatches.cs
+++ b/Imperium/src/Patches/PreInitPatches.cs
@@ -46,6 +46,7 @@ internal static class PreInitPatches
             }
             else
             {
+                // Fixes imperium not working when using a mod that enables the lobby menu in singleplayer
                 Imperium.Networking.OnAuthenticateResponse();
             }
         }


### PR DESCRIPTION
- Added the "Splash Screen" level to the level blacklist
- Removed the "Recording" level from the level blacklist
- Changed the `IsGameLevel` check to use the base-game methods
- Fixed imperium not working in singleplayer when using a mod that enables the lobby menu for singleplayer