### PR TITLE
Fix item spawn command registration in F2 console

### DIFF
--- a/Imperium/src/Console/ConsoleManager.cs
+++ b/Imperium/src/Console/ConsoleManager.cs
@@ -26,6 +26,7 @@ internal class ConsoleManager : ImpLifecycleObject
     private void Awake()
     {
         RegisterLevelCommands();
+        RegisterSpawnCommands();
         Imperium.ObjectManager.CurrentLevelObjectsChanged += RegisterSpawnCommands;
     }
 

--- a/Imperium/src/Core/Lifecycle/ObjectManager.cs
+++ b/Imperium/src/Core/Lifecycle/ObjectManager.cs
@@ -141,7 +141,11 @@ internal class ObjectManager : ImpLifecycleObject
         }
     }
 
-    protected override void OnLevelLoad() => RefreshLevelObjects();
+    protected override void OnLevelLoad()
+    {
+        FetchGlobalSpawnLists();
+        RefreshLevelObjects();
+    }
 
     protected override void OnPlayersUpdate(int playersConnected) => FetchPlayers();
 
@@ -270,7 +274,29 @@ internal class ObjectManager : ImpLifecycleObject
             loadedEntityNames.Add(parent.enemyName);
         }
 
-        var allItems = StatsManager.instance.itemDictionary.Values.Select(x => x.prefab).OrderBy(x => x.PrefabName).ToList();
+        var resourceItems = Resources.FindObjectsOfTypeAll<Item>().Where(item => item != null).ToList();
+        var statsManagerItems = StatsManager.instance
+            ? StatsManager.instance.itemDictionary.Values.Where(item => item != null).ToList()
+            : [];
+        var shopItems = ShopManager.instance
+            ? ShopManager.instance.potentialItems
+                .Concat(ShopManager.instance.potentialItemConsumables)
+                .Concat(ShopManager.instance.potentialItemHealthPacks)
+                .Concat(ShopManager.instance.potentialItemUpgrades)
+                .Concat(ShopManager.instance.potentialSecretItems.Values.SelectMany(items => items))
+                .Where(item => item != null)
+                .ToList()
+            : [];
+
+        var allItems = resourceItems
+            .Concat(statsManagerItems)
+            .Concat(shopItems)
+            .Select(item => item.prefab)
+            .Where(prefab => prefab != null && prefab.IsValid())
+            .GroupBy(prefab => prefab.PrefabName)
+            .Select(group => group.First())
+            .OrderBy(prefab => prefab.PrefabName)
+            .ToList();
         var allLevels = Resources.FindObjectsOfTypeAll<Level>()
             .Where(level => !ImpConstants.LevelBlacklist.Contains(level.NarrativeName))
             .OrderBy(x => x.NarrativeName).ToList();


### PR DESCRIPTION
## Summary

Fixed an issue where item candidates were not properly listed in the F2 console entity spawn popup.

## Cause

Item spawn commands are registered in `ConsoleManager.RegisterSpawnCommands()` based on `ObjectManager.LoadedItems`.

Previously, `LoadedItems` was populated only from `StatsManager.instance.itemDictionary`. However, this dictionary is not always fully populated as a complete spawn catalog when Imperium initializes. As a result, only a very small number of items, sometimes just one, were added to `LoadedItems`, causing most item spawn candidates to be missing from the F2 console.

Additionally, `ObjectManager` is created before `ConsoleManager`, so the initial object update event could fire before `ConsoleManager` subscribes to it. In that case, the first spawn command registration could be missed.

## Changes

- Expanded the item sources used by `ObjectManager.FetchGlobalSpawnLists()`.
- Combined item candidates from `Resources.FindObjectsOfTypeAll<Item>()`, `StatsManager.instance.itemDictionary`, and `ShopManager` item lists.
- Filtered valid `PrefabRef` values, deduplicated them by `PrefabName`, and registered the result in `LoadedItems`.
- Re-ran `FetchGlobalSpawnLists()` from `ObjectManager.OnLevelLoad()` so item data initialized during level loading can be picked up reliably.
- Explicitly call `RegisterSpawnCommands()` from `ConsoleManager.Awake()` so spawn commands are registered even if the initial update event was fired before subscription.